### PR TITLE
Ispravka u kodu za Dijkstrin algoritam

### DIFF
--- a/2018.2019/02.pretraga/Pretraga.ipynb
+++ b/2018.2019/02.pretraga/Pretraga.ipynb
@@ -401,7 +401,7 @@
     "                    n = w\n",
     "\n",
     "            # Ako ne postoji cvor cija je udaljenost manja od beskonacnosti, put od polaznog do ciljnog cvora ne postoji\n",
-    "            if n == None:\n",
+    "            if D[n] == float('inf'):\n",
     "                print('Trazeni put ne postoji')\n",
     "                return None\n",
     "\n",


### PR DESCRIPTION
U prethodnom kodu se nikada ne ulazi u tu granu jer se prethodno u for petlji svakako dodeljuje n na nesto sto nije None, i zato ne radi za cvorove u razlicitim komponentama povezanosti.